### PR TITLE
Customer Request - Bug #243504 fix: After the first login, the user i…

### DIFF
--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -123,15 +123,36 @@ function Header({ globalSearchQuery }) {
   }, []);
 
   // Retrieve roles from sessionStorage
-  //const rolesJson = sessionStorage.getItem("roles");
+  //Polling approach
+
   useEffect(() => {
-    const rolesJson = sessionStorage.getItem("roles");
-    if (rolesJson) {
-      parsedRoles = JSON.parse(rolesJson);
-      setRoles(parsedRoles);
-      checkAccess(JSON.parse(sessionStorage.getItem("roles")));
-    }
+    let intervalId;
+    let attempts = 0;
+
+    const checkRolesAndAccess = () => {
+      const rolesJson = sessionStorage.getItem("roles");
+      console.log("rolesJson", rolesJson)
+      if (rolesJson) {
+        const parsedRoles = JSON.parse(rolesJson);
+        setRoles(parsedRoles);
+        checkAccess(parsedRoles);
+        clearInterval(intervalId); // Stop polling once roles are found and handled
+      } else if (attempts >= 10) {
+        clearInterval(intervalId); // Avoid infinite loops
+        console.warn("Roles not found in sessionStorage after waiting.");
+      }
+      attempts++;
+    };
+
+    checkRolesAndAccess(); // Try once immediately
+
+    intervalId = setInterval(checkRolesAndAccess, 300); // Try again every 300ms
+
+    return () => clearInterval(intervalId); // Clean up
   }, []);
+
+
+
   const handleOpenNavMenu = (event) => {
     setAnchorElNav(event.currentTarget);
   };


### PR DESCRIPTION
Customer Request - Bug #243504

## Description

After the first login, the user is unable to see the workspace
After the first login, the user is unable to see the workspace.
After the second login, the user can see the workspace and can click on it to land on the workspace page.
However, if the user reloads the page, they get logged out.


### Changes

Added polling approach to get the roles from session storage

## How to test

login to app and check if workspace is accessible to the user (Note: try different browser like firefox, edge)

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)