### PR TITLE
Fix: Add CONTENT_REVIEWER role to workspace visibility checks in head…

### DIFF
--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -640,7 +640,7 @@ function Header({ globalSearchQuery }) {
               {/* Check if roles array is empty or contains "PUBLIC" */}
 
               {/* {accessWorkspace && ( */}
-              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER"].includes(role)) && (
+              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)) && (
                 <Link
                   target="_blank"
                   href="/workspace/content/create"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -640,7 +640,7 @@ function Header({ globalSearchQuery }) {
               {/* Check if roles array is empty or contains "PUBLIC" */}
 
               {/* {accessWorkspace && ( */}
-              {roleNames.some((role) => ["CONTENT_CREATOR"].includes(role)) && (
+              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER"].includes(role)) && (
                 <Link
                   target="_blank"
                   href="/workspace/content/create"
@@ -1020,9 +1020,9 @@ function Header({ globalSearchQuery }) {
                       "ORG_ADMIN",
                       "SYSTEM_ADMINISTRATION",
                       "CONTENT_CREATOR",
+                      "CONTENT_REVIEWER",
                     ].includes(role)
-                  ) &&
-                    accessWorkspace && (
+                  ) && (
                       <Link
                         target="_blank"
                         href="/workspace/content/create"


### PR DESCRIPTION
…er.js

<!-- Please refer to CONTRIBUTING.md (https://github.com/shiksha-platform/frontend-modulefederation/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Add CONTENT_REVIEWER to workspace visibility checks so reviewers can see the workspace menu item.

### Changes

Desktop View (header.js - line 643): Added CONTENT_REVIEWER to the workspace menu visibility check
Changed from: ["CONTENT_CREATOR"]
Changed to: ["CONTENT_CREATOR", "CONTENT_REVIEWER"]
Mobile View (header.js - lines 1018-1034): Added CONTENT_REVIEWER to the mobile workspace menu visibility check
Added "CONTENT_REVIEWER" to the role check array: ["ORG_ADMIN", "SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER"]
Removed the accessWorkspace dependency requirement for consistency with desktop view
Files Modified:
src/app/nulp-elite-ui/packages/nulp_elite/src/components/header.js
Root Cause:
The /learnathon/get/creators API returns an empty array for CONTENT_REVIEWER users (they aren't in the user_rolles table used by learnathon). Although checkAccess includes CONTENT_REVIEWER as a valid role, the UI visibility checks were excluding it.

## How to test

Log in as a user with the CONTENT_REVIEWER role.
Verify the "WORKSPACE" menu item appears:
Desktop: In the profile dropdown menu
Mobile: In the mobile menu
Click the workspace link and confirm it navigates to /workspace/content/create.
Verify other roles (CONTENT_CREATOR, ORG_ADMIN, SYSTEM_ADMINISTRATION) still see the workspace menu as before.
Expected Result:
CONTENT_REVIEWER users can see and access the workspace menu item in both desktop and mobile views.
Workspace functionality works for CONTENT_REVIEWER users.
Previous Behavior:
CONTENT_REVIEWER users could not see the workspace menu item despite having the role.
Console Verification:
Check browser console for rolesJson ["CONTENT_REVIEWER"].
The workspace menu should be visible regardless of an empty response from /learnathon/get/creators.

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)