### PR TITLE
Bug #249281: Poll option is missing in Menu for the end users and the creators

### DIFF
--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -650,67 +650,69 @@ function Header({ globalSearchQuery }) {
                   <MenuItem>{t("WORKSPACE")}</MenuItem>
                 </Link>
               )}
-              <MenuItem
-                onClick={handleSubmenuToggle}
-                style={{ background: "#f9fafc", color: "#1976d2" }}
-                className="lg-hide"
-              >
-                {t("POLL")}
-                <Link primary="Submenu" />
-                {openSubmenu ? <ExpandLess /> : <ExpandMore />}
-              </MenuItem>
-              <Collapse
-                in={openSubmenu}
-                timeout="auto"
-                unmountOnExit
-                className="lg-hide"
-              >
-                <List
-                  component="div"
-                  disablePadding
-                  style={{ background: "#f9fafc" }}
-                >
-                  {roleNames.some((role) =>
-                    ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(role)
-                  ) &&
-                    accessWorkspace && (
-                      <MenuItem
-                        className="ml-10"
-                        style={{ background: "#f9fafc" }}
-                      >
+              {(roleNames.some((role) =>
+                ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)
+              )) && (
+                <>
+                  <MenuItem
+                    onClick={handleSubmenuToggle}
+                    style={{ background: "#f9fafc", color: "#1976d2" }}
+                  >
+                    {t("POLL")}
+                    <Link primary="Submenu" />
+                    {openSubmenu ? <ExpandLess /> : <ExpandMore />}
+                  </MenuItem>
+                  <Collapse
+                    in={openSubmenu}
+                    timeout="auto"
+                    unmountOnExit
+                  >
+                    <List
+                      component="div"
+                      disablePadding
+                      style={{ background: "#f9fafc" }}
+                    >
+                      {roleNames.some((role) =>
+                        ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(role)
+                      ) &&
+                        accessWorkspace && (
+                          <MenuItem
+                            className="ml-10"
+                            style={{ background: "#f9fafc" }}
+                          >
+                            <Link
+                              href={routeConfig.ROUTES.POLL.POLL_FORM}
+                              underline="none"
+                              textAlign="center"
+                            >
+                              {t("CREATE_POLL")}
+                            </Link>
+                          </MenuItem>
+                        )}
+                      <MenuItem className="ml-10">
                         <Link
-                          href={routeConfig.ROUTES.POLL.POLL_FORM}
+                          href={routeConfig.ROUTES.POLL.POLL_LIST}
                           underline="none"
                           textAlign="center"
                         >
-                          {t("CREATE_POLL")}
+                          {t("POLL_LIST")}
                         </Link>
                       </MenuItem>
-                    )}
-                  <MenuItem className="ml-10">
-                    <Link
-                      href={routeConfig.ROUTES.POLL.POLL_LIST}
-                      underline="none"
-                      textAlign="center"
-                    >
-                      {t("POLL_LIST")}
-                    </Link>
-                  </MenuItem>
-                  {roleNames.some((role) =>
-                    ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(role)
-                  ) && (
-                    <MenuItem className="ml-10">
-                      <Link
-                        href={routeConfig.ROUTES.POLL.POLL_DASHBOARD}
-                        underline="none"
-                        textAlign="center"
-                      >
-                        {t("DASHBOARD")}
-                      </Link>
-                    </MenuItem>
-                  )}
-                </List>
-              </Collapse>
+                    </List>
+                  </Collapse>
+                </>
+              )}
+              {!roleNames.some((role) =>
+                ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)
+              ) && (
+                <Link
+                  href={routeConfig.ROUTES.POLL.POLL_LIST}
+                  underline="none"
+                  textAlign="center"
+                >
+                  <MenuItem>{t("POLL_LIST")}</MenuItem>
+                </Link>
+              )}
               <Link
                 href={routeConfig.ROUTES.HELP_PAGE.HELP}
                 underline="none"
@@ -1035,49 +1037,70 @@ function Header({ globalSearchQuery }) {
                   {/* <NotificationsNoneOutlinedIcon />
                     ekta */}
 
-                  <MenuItem
-                    onClick={handleSubmenuToggle}
-                    style={{ background: "#f9fafc", color: "#1976d2" }}
-                  >
-                    {t("POLL")}
-                    <Link primary="Submenu" />
-                    {openSubmenu ? <ExpandLess /> : <ExpandMore />}
-                  </MenuItem>
-                  <Collapse
-                    in={openSubmenu}
-                    timeout="auto"
-                    unmountOnExit
-                    style={{ background: "#f9fafc" }}
-                  >
-                    <List
-                      component="div"
-                      disablePadding
-                      style={{ background: "#f9fafc" }}
-                    >
-                      {roleNames.some((role) =>
-                        ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(
-                          role
-                        )
-                      ) && (
-                        <Link
-                          href={routeConfig.ROUTES.POLL.POLL_FORM}
-                          underline="none"
-                          textAlign="center"
-                        >
-                          <MenuItem className="ml-10">
-                            {t("CREATE_POLL")}
-                          </MenuItem>
-                        </Link>
-                      )}
-                      <Link
-                        href={routeConfig.ROUTES.POLL.POLL_LIST}
-                        underline="none"
-                        textAlign="center"
+                  {(roleNames.some((role) =>
+                    ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(
+                      role
+                    )
+                  )) && (
+                    <>
+                      <MenuItem
+                        onClick={handleSubmenuToggle}
+                        style={{ background: "#f9fafc", color: "#1976d2" }}
                       >
-                        <MenuItem className="ml-10">{t("POLL_LIST")}</MenuItem>
-                      </Link>
-                    </List>
-                  </Collapse>
+                        {t("POLL")}
+                        <Link primary="Submenu" />
+                        {openSubmenu ? <ExpandLess /> : <ExpandMore />}
+                      </MenuItem>
+                      <Collapse
+                        in={openSubmenu}
+                        timeout="auto"
+                        unmountOnExit
+                        style={{ background: "#f9fafc" }}
+                      >
+                        <List
+                          component="div"
+                          disablePadding
+                          style={{ background: "#f9fafc" }}
+                        >
+                          {roleNames.some((role) =>
+                            ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(
+                              role
+                            )
+                          ) && (
+                            <Link
+                              href={routeConfig.ROUTES.POLL.POLL_FORM}
+                              underline="none"
+                              textAlign="center"
+                            >
+                              <MenuItem className="ml-10">
+                                {t("CREATE_POLL")}
+                              </MenuItem>
+                            </Link>
+                          )}
+                          <Link
+                            href={routeConfig.ROUTES.POLL.POLL_LIST}
+                            underline="none"
+                            textAlign="center"
+                          >
+                            <MenuItem className="ml-10">{t("POLL_LIST")}</MenuItem>
+                          </Link>
+                        </List>
+                      </Collapse>
+                    </>
+                  )}
+                  {!roleNames.some((role) =>
+                    ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(
+                      role
+                    )
+                  ) && (
+                    <Link
+                      href={routeConfig.ROUTES.POLL.POLL_LIST}
+                      underline="none"
+                      textAlign="center"
+                    >
+                      <MenuItem>{t("POLL_LIST")}</MenuItem>
+                    </Link>
+                  )}
                   <Link
                     href={routeConfig.ROUTES.HELP_PAGE.HELP}
                     underline="none"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
@@ -34,6 +35,32 @@ import { ExpandLess, ExpandMore } from "@mui/icons-material";
 import { Collapse, List } from "@mui/material";
 import NotificationPopup from "./Notification";
 import Cookies from "js-cookie";
+
+// Constants for role-based access control
+const PRIVILEGED_POLL_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"]);
+const POLL_CREATOR_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"]);
+
+// Reusable POLL_LIST link component
+const PollListLink = ({ className = "" }) => {
+  const { t } = useTranslation();
+  return (
+    <Link
+      href={routeConfig.ROUTES.POLL.POLL_LIST}
+      underline="none"
+      textAlign="center"
+    >
+      <MenuItem className={className}>{t("POLL_LIST")}</MenuItem>
+    </Link>
+  );
+};
+
+PollListLink.propTypes = {
+  className: PropTypes.string,
+};
+
+PollListLink.defaultProps = {
+  className: "",
+};
 
 function Header({ globalSearchQuery }) {
   const navigate = useNavigate();
@@ -295,30 +322,15 @@ function Header({ globalSearchQuery }) {
   const roleNames =
     userData?.result?.response?.roles.map((role) => role.role) || [];
 
-  // Constants for role-based access control
-  const PRIVILEGED_POLL_ROLES = ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"];
-  const POLL_CREATOR_ROLES = ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"];
-
   // Helper function to check if user has privileged poll roles
   const hasPrivilegedPollAccess = () => {
-    return roleNames.some((role) => PRIVILEGED_POLL_ROLES.includes(role));
+    return roleNames.some((role) => PRIVILEGED_POLL_ROLES.has(role));
   };
 
   // Helper function to check if user can create polls
   const canCreatePoll = () => {
-    return roleNames.some((role) => POLL_CREATOR_ROLES.includes(role));
+    return roleNames.some((role) => POLL_CREATOR_ROLES.has(role));
   };
-
-  // Reusable POLL_LIST link component
-  const PollListLink = ({ className = "" }) => (
-    <Link
-      href={routeConfig.ROUTES.POLL.POLL_LIST}
-      underline="none"
-      textAlign="center"
-    >
-      <MenuItem className={className}>{t("POLL_LIST")}</MenuItem>
-    </Link>
-  );
 
   const textFieldStyle = {
     fontSize: "12px",

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -39,20 +39,34 @@ import Cookies from "js-cookie";
 // Constants for role-based access control
 const PRIVILEGED_POLL_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"]);
 const POLL_CREATOR_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"]);
+const ADMIN_DASHBOARD_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "ORG_ADMIN"]);
+const DASHBOARD_ROLES = new Set(["CONTENT_CREATOR"]);
+const WORKSPACE_ROLES = new Set(["CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"]);
+const WORKSPACE_MOBILE_ROLES = new Set(["ORG_ADMIN", "SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER"]);
+const POLL_DASHBOARD_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"]);
+const EVENTS_ROLES = new Set(["ORG_ADMIN", "SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"]);
+const LEARNATHON_ROLES = new Set(["ORG_ADMIN", "SYSTEM_ADMINISTRATION"]);
+const ADMIN_ROLES = new Set(["ORG_ADMIN", "SYSTEM_ADMINISTRATION"]);
 
 // Helper function to check if user has any of the specified roles
 const hasAnyRole = (roleNames, allowedRoles) => {
+  if (!roleNames || !Array.isArray(roleNames)) return false;
   return roleNames.some((role) => allowedRoles.has(role));
+};
+
+// Uniform helper function for role-based access checks
+const hasRoleAccess = (roleNames, roleSet) => {
+  return hasAnyRole(roleNames, roleSet);
 };
 
 // Helper function to check if user has privileged poll roles
 const hasPrivilegedPollAccess = (roleNames) => {
-  return hasAnyRole(roleNames, PRIVILEGED_POLL_ROLES);
+  return hasRoleAccess(roleNames, PRIVILEGED_POLL_ROLES);
 };
 
 // Helper function to check if user can create polls
 const canCreatePoll = (roleNames) => {
-  return hasAnyRole(roleNames, POLL_CREATOR_ROLES);
+  return hasRoleAccess(roleNames, POLL_CREATOR_ROLES);
 };
 
 // Reusable POLL_LIST link component
@@ -747,9 +761,7 @@ function Header({ globalSearchQuery }) {
               >
                 <MenuItem>{t("PROFILE")}</MenuItem>
               </Link>
-              {roleNames.some((role) => 
-                ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "ORG_ADMIN"].includes(role)
-              ) && (
+              {hasRoleAccess(roleNames, ADMIN_DASHBOARD_ROLES) && (
                 <Link
                   target="_blank"
                   href={urlConfig.DASHBOARD.ADMIN_DASHBOARD_URL}
@@ -759,7 +771,7 @@ function Header({ globalSearchQuery }) {
                   <MenuItem>{t("ADMIN_DASHBOARD")}</MenuItem>
                 </Link>
               )}
-              {roleNames.some((role) => ["CONTENT_CREATOR"].includes(role)) && (
+              {hasRoleAccess(roleNames, DASHBOARD_ROLES) && (
                 <Link
                   href={routeConfig.ROUTES.DASHBOARD_PAGE.DASHBOARD}
                   underline="none"
@@ -772,7 +784,7 @@ function Header({ globalSearchQuery }) {
               {/* Check if roles array is empty or contains "PUBLIC" */}
 
               {/* {accessWorkspace && ( */}
-              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)) && (
+              {hasRoleAccess(roleNames, WORKSPACE_ROLES) && (
                 <Link
                   target="_blank"
                   href="/workspace/content/create"
@@ -1019,11 +1031,7 @@ function Header({ globalSearchQuery }) {
                       disablePadding
                       style={{ background: "#f9fafc" }}
                     >
-                      {roleNames.some((role) =>
-                        ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(
-                          role
-                        )
-                      ) && (
+                      {hasRoleAccess(roleNames, POLL_DASHBOARD_ROLES) && (
                         <Link
                           href={routeConfig.ROUTES.POLL.POLL_DASHBOARD}
                           underline="none"
@@ -1032,13 +1040,7 @@ function Header({ globalSearchQuery }) {
                           <MenuItem className="ml-10">{t("POLL")}</MenuItem>
                         </Link>
                       )}
-                      {roleNames.some((role) =>
-                        [
-                          "ORG_ADMIN",
-                          "SYSTEM_ADMINISTRATION",
-                          "CONTENT_CREATOR",
-                        ].includes(role)
-                      ) && (
+                      {hasRoleAccess(roleNames, EVENTS_ROLES) && (
                         <Link
                           href={routeConfig.ROUTES.DASHBOARD_PAGE.DASHBOARD}
                           underline="none"
@@ -1060,9 +1062,7 @@ function Header({ globalSearchQuery }) {
                       >
                         {t("LEARNING_REPORT")}
                       </MenuItem>
-                      {roleNames.some((role) =>
-                        ["ORG_ADMIN", "SYSTEM_ADMINISTRATION"].includes(role)
-                      ) && (
+                      {hasRoleAccess(roleNames, LEARNATHON_ROLES) && (
                         <Link
                           href={routeConfig.ROUTES.LEARNATHON.DASHBOARD}
                           underline="none"
@@ -1079,9 +1079,7 @@ function Header({ globalSearchQuery }) {
                       )}
                     </List>
                   </Collapse>
-                  {roleNames.some((role) =>
-                    ["ORG_ADMIN", "SYSTEM_ADMINISTRATION"].includes(role)
-                  ) && (
+                  {hasRoleAccess(roleNames, ADMIN_ROLES) && (
                     <Link
                       href={routeConfig.ROUTES.ADMIN}
                       underline="none"
@@ -1092,14 +1090,7 @@ function Header({ globalSearchQuery }) {
                     </Link>
                   )}
 
-                  {roleNames.some((role) =>
-                    [
-                      "ORG_ADMIN",
-                      "SYSTEM_ADMINISTRATION",
-                      "CONTENT_CREATOR",
-                      "CONTENT_REVIEWER",
-                    ].includes(role)
-                  ) && (
+                  {hasRoleAccess(roleNames, WORKSPACE_MOBILE_ROLES) && (
                       <Link
                         target="_blank"
                         href="/workspace/content/create"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -640,7 +640,7 @@ function Header({ globalSearchQuery }) {
               {/* Check if roles array is empty or contains "PUBLIC" */}
 
               {/* {accessWorkspace && ( */}
-              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER"].includes(role)) && (
+              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)) && (
                 <Link
                   target="_blank"
                   href="/workspace/content/create"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -640,7 +640,7 @@ function Header({ globalSearchQuery }) {
               {/* Check if roles array is empty or contains "PUBLIC" */}
 
               {/* {accessWorkspace && ( */}
-              {roleNames.some((role) => ["CONTENT_CREATOR"].includes(role)) && (
+              {roleNames.some((role) => ["CONTENT_CREATOR", "CONTENT_REVIEWER"].includes(role)) && (
                 <Link
                   target="_blank"
                   href="/workspace/content/create"
@@ -1020,9 +1020,9 @@ function Header({ globalSearchQuery }) {
                       "ORG_ADMIN",
                       "SYSTEM_ADMINISTRATION",
                       "CONTENT_CREATOR",
+                      "CONTENT_REVIEWER",
                     ].includes(role)
-                  ) &&
-                    accessWorkspace && (
+                  ) && (
                       <Link
                         target="_blank"
                         href="/workspace/content/create"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -40,6 +40,21 @@ import Cookies from "js-cookie";
 const PRIVILEGED_POLL_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"]);
 const POLL_CREATOR_ROLES = new Set(["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"]);
 
+// Helper function to check if user has any of the specified roles
+const hasAnyRole = (roleNames, allowedRoles) => {
+  return roleNames.some((role) => allowedRoles.has(role));
+};
+
+// Helper function to check if user has privileged poll roles
+const hasPrivilegedPollAccess = (roleNames) => {
+  return hasAnyRole(roleNames, PRIVILEGED_POLL_ROLES);
+};
+
+// Helper function to check if user can create polls
+const canCreatePoll = (roleNames) => {
+  return hasAnyRole(roleNames, POLL_CREATOR_ROLES);
+};
+
 // Reusable POLL_LIST link component
 const PollListLink = ({ className = "" }) => {
   const { t } = useTranslation();
@@ -321,16 +336,6 @@ function Header({ globalSearchQuery }) {
   }, []);
   const roleNames =
     userData?.result?.response?.roles.map((role) => role.role) || [];
-
-  // Helper function to check if user has privileged poll roles
-  const hasPrivilegedPollAccess = () => {
-    return roleNames.some((role) => PRIVILEGED_POLL_ROLES.has(role));
-  };
-
-  // Helper function to check if user can create polls
-  const canCreatePoll = () => {
-    return roleNames.some((role) => POLL_CREATOR_ROLES.has(role));
-  };
 
   const textFieldStyle = {
     fontSize: "12px",
@@ -687,7 +692,7 @@ function Header({ globalSearchQuery }) {
                   <MenuItem>{t("WORKSPACE")}</MenuItem>
                 </Link>
               )}
-              {hasPrivilegedPollAccess() && (
+              {hasPrivilegedPollAccess(roleNames) && (
                 <>
                   <MenuItem
                     onClick={handleSubmenuToggle}
@@ -707,7 +712,7 @@ function Header({ globalSearchQuery }) {
                       disablePadding
                       style={{ background: "#f9fafc" }}
                     >
-                      {canCreatePoll() && (
+                      {canCreatePoll(roleNames) && (
                         <MenuItem
                           className="ml-10"
                           style={{ background: "#f9fafc" }}
@@ -734,7 +739,7 @@ function Header({ globalSearchQuery }) {
                   </Collapse>
                 </>
               )}
-              {!hasPrivilegedPollAccess() && <PollListLink />}
+              {!hasPrivilegedPollAccess(roleNames) && <PollListLink />}
               <Link
                 href={routeConfig.ROUTES.HELP_PAGE.HELP}
                 underline="none"
@@ -1059,7 +1064,7 @@ function Header({ globalSearchQuery }) {
                   {/* <NotificationsNoneOutlinedIcon />
                     ekta */}
 
-                  {hasPrivilegedPollAccess() && (
+                  {hasPrivilegedPollAccess(roleNames) && (
                     <>
                       <MenuItem
                         onClick={handleSubmenuToggle}
@@ -1080,7 +1085,7 @@ function Header({ globalSearchQuery }) {
                           disablePadding
                           style={{ background: "#f9fafc" }}
                         >
-                          {canCreatePoll() && (
+                          {canCreatePoll(roleNames) && (
                             <Link
                               href={routeConfig.ROUTES.POLL.POLL_FORM}
                               underline="none"
@@ -1102,7 +1107,7 @@ function Header({ globalSearchQuery }) {
                       </Collapse>
                     </>
                   )}
-                  {!hasPrivilegedPollAccess() && <PollListLink />}
+                  {!hasPrivilegedPollAccess(roleNames) && <PollListLink />}
                   <Link
                     href={routeConfig.ROUTES.HELP_PAGE.HELP}
                     underline="none"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -77,6 +77,96 @@ PollListLink.defaultProps = {
   className: "",
 };
 
+// Reusable Poll Submenu component
+const PollSubmenu = ({ 
+  roleNames, 
+  openSubmenu, 
+  onToggle, 
+  isMobile = false 
+}) => {
+  const { t } = useTranslation();
+  const submenuStyle = { background: "#f9fafc", color: "#1976d2" };
+  const listStyle = { background: "#f9fafc" };
+
+  if (!hasPrivilegedPollAccess(roleNames)) {
+    return <PollListLink />;
+  }
+
+  return (
+    <>
+      <MenuItem onClick={onToggle} style={submenuStyle}>
+        {t("POLL")}
+        <Link primary="Submenu" />
+        {openSubmenu ? <ExpandLess /> : <ExpandMore />}
+      </MenuItem>
+      <Collapse
+        in={openSubmenu}
+        timeout="auto"
+        unmountOnExit
+        style={isMobile ? listStyle : undefined}
+      >
+        <List
+          component="div"
+          disablePadding
+          style={listStyle}
+        >
+          {canCreatePoll(roleNames) && (
+            isMobile ? (
+              <Link
+                href={routeConfig.ROUTES.POLL.POLL_FORM}
+                underline="none"
+                textAlign="center"
+              >
+                <MenuItem className="ml-10">{t("CREATE_POLL")}</MenuItem>
+              </Link>
+            ) : (
+              <MenuItem className="ml-10" style={listStyle}>
+                <Link
+                  href={routeConfig.ROUTES.POLL.POLL_FORM}
+                  underline="none"
+                  textAlign="center"
+                >
+                  {t("CREATE_POLL")}
+                </Link>
+              </MenuItem>
+            )
+          )}
+          {isMobile ? (
+            <Link
+              href={routeConfig.ROUTES.POLL.POLL_LIST}
+              underline="none"
+              textAlign="center"
+            >
+              <MenuItem className="ml-10">{t("POLL_LIST")}</MenuItem>
+            </Link>
+          ) : (
+            <MenuItem className="ml-10">
+              <Link
+                href={routeConfig.ROUTES.POLL.POLL_LIST}
+                underline="none"
+                textAlign="center"
+              >
+                {t("POLL_LIST")}
+              </Link>
+            </MenuItem>
+          )}
+        </List>
+      </Collapse>
+    </>
+  );
+};
+
+PollSubmenu.propTypes = {
+  roleNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+  openSubmenu: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  isMobile: PropTypes.bool,
+};
+
+PollSubmenu.defaultProps = {
+  isMobile: false,
+};
+
 function Header({ globalSearchQuery }) {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -692,54 +782,12 @@ function Header({ globalSearchQuery }) {
                   <MenuItem>{t("WORKSPACE")}</MenuItem>
                 </Link>
               )}
-              {hasPrivilegedPollAccess(roleNames) && (
-                <>
-                  <MenuItem
-                    onClick={handleSubmenuToggle}
-                    style={{ background: "#f9fafc", color: "#1976d2" }}
-                  >
-                    {t("POLL")}
-                    <Link primary="Submenu" />
-                    {openSubmenu ? <ExpandLess /> : <ExpandMore />}
-                  </MenuItem>
-                  <Collapse
-                    in={openSubmenu}
-                    timeout="auto"
-                    unmountOnExit
-                  >
-                    <List
-                      component="div"
-                      disablePadding
-                      style={{ background: "#f9fafc" }}
-                    >
-                      {canCreatePoll(roleNames) && (
-                        <MenuItem
-                          className="ml-10"
-                          style={{ background: "#f9fafc" }}
-                        >
-                          <Link
-                            href={routeConfig.ROUTES.POLL.POLL_FORM}
-                            underline="none"
-                            textAlign="center"
-                          >
-                            {t("CREATE_POLL")}
-                          </Link>
-                        </MenuItem>
-                      )}
-                      <MenuItem className="ml-10">
-                        <Link
-                          href={routeConfig.ROUTES.POLL.POLL_LIST}
-                          underline="none"
-                          textAlign="center"
-                        >
-                          {t("POLL_LIST")}
-                        </Link>
-                      </MenuItem>
-                    </List>
-                  </Collapse>
-                </>
-              )}
-              {!hasPrivilegedPollAccess(roleNames) && <PollListLink />}
+              <PollSubmenu
+                roleNames={roleNames}
+                openSubmenu={openSubmenu}
+                onToggle={handleSubmenuToggle}
+                isMobile={false}
+              />
               <Link
                 href={routeConfig.ROUTES.HELP_PAGE.HELP}
                 underline="none"
@@ -1064,50 +1112,12 @@ function Header({ globalSearchQuery }) {
                   {/* <NotificationsNoneOutlinedIcon />
                     ekta */}
 
-                  {hasPrivilegedPollAccess(roleNames) && (
-                    <>
-                      <MenuItem
-                        onClick={handleSubmenuToggle}
-                        style={{ background: "#f9fafc", color: "#1976d2" }}
-                      >
-                        {t("POLL")}
-                        <Link primary="Submenu" />
-                        {openSubmenu ? <ExpandLess /> : <ExpandMore />}
-                      </MenuItem>
-                      <Collapse
-                        in={openSubmenu}
-                        timeout="auto"
-                        unmountOnExit
-                        style={{ background: "#f9fafc" }}
-                      >
-                        <List
-                          component="div"
-                          disablePadding
-                          style={{ background: "#f9fafc" }}
-                        >
-                          {canCreatePoll(roleNames) && (
-                            <Link
-                              href={routeConfig.ROUTES.POLL.POLL_FORM}
-                              underline="none"
-                              textAlign="center"
-                            >
-                              <MenuItem className="ml-10">
-                                {t("CREATE_POLL")}
-                              </MenuItem>
-                            </Link>
-                          )}
-                          <Link
-                            href={routeConfig.ROUTES.POLL.POLL_LIST}
-                            underline="none"
-                            textAlign="center"
-                          >
-                            <MenuItem className="ml-10">{t("POLL_LIST")}</MenuItem>
-                          </Link>
-                        </List>
-                      </Collapse>
-                    </>
-                  )}
-                  {!hasPrivilegedPollAccess(roleNames) && <PollListLink />}
+                  <PollSubmenu
+                    roleNames={roleNames}
+                    openSubmenu={openSubmenu}
+                    onToggle={handleSubmenuToggle}
+                    isMobile={true}
+                  />
                   <Link
                     href={routeConfig.ROUTES.HELP_PAGE.HELP}
                     underline="none"

--- a/packages/nulp_elite/src/components/header.js
+++ b/packages/nulp_elite/src/components/header.js
@@ -295,6 +295,31 @@ function Header({ globalSearchQuery }) {
   const roleNames =
     userData?.result?.response?.roles.map((role) => role.role) || [];
 
+  // Constants for role-based access control
+  const PRIVILEGED_POLL_ROLES = ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"];
+  const POLL_CREATOR_ROLES = ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"];
+
+  // Helper function to check if user has privileged poll roles
+  const hasPrivilegedPollAccess = () => {
+    return roleNames.some((role) => PRIVILEGED_POLL_ROLES.includes(role));
+  };
+
+  // Helper function to check if user can create polls
+  const canCreatePoll = () => {
+    return roleNames.some((role) => POLL_CREATOR_ROLES.includes(role));
+  };
+
+  // Reusable POLL_LIST link component
+  const PollListLink = ({ className = "" }) => (
+    <Link
+      href={routeConfig.ROUTES.POLL.POLL_LIST}
+      underline="none"
+      textAlign="center"
+    >
+      <MenuItem className={className}>{t("POLL_LIST")}</MenuItem>
+    </Link>
+  );
+
   const textFieldStyle = {
     fontSize: "12px",
     backgroundColor: searchQuery ? "#065872" : "transparent",
@@ -650,9 +675,7 @@ function Header({ globalSearchQuery }) {
                   <MenuItem>{t("WORKSPACE")}</MenuItem>
                 </Link>
               )}
-              {(roleNames.some((role) =>
-                ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)
-              )) && (
+              {hasPrivilegedPollAccess() && (
                 <>
                   <MenuItem
                     onClick={handleSubmenuToggle}
@@ -672,23 +695,20 @@ function Header({ globalSearchQuery }) {
                       disablePadding
                       style={{ background: "#f9fafc" }}
                     >
-                      {roleNames.some((role) =>
-                        ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(role)
-                      ) &&
-                        accessWorkspace && (
-                          <MenuItem
-                            className="ml-10"
-                            style={{ background: "#f9fafc" }}
+                      {canCreatePoll() && (
+                        <MenuItem
+                          className="ml-10"
+                          style={{ background: "#f9fafc" }}
+                        >
+                          <Link
+                            href={routeConfig.ROUTES.POLL.POLL_FORM}
+                            underline="none"
+                            textAlign="center"
                           >
-                            <Link
-                              href={routeConfig.ROUTES.POLL.POLL_FORM}
-                              underline="none"
-                              textAlign="center"
-                            >
-                              {t("CREATE_POLL")}
-                            </Link>
-                          </MenuItem>
-                        )}
+                            {t("CREATE_POLL")}
+                          </Link>
+                        </MenuItem>
+                      )}
                       <MenuItem className="ml-10">
                         <Link
                           href={routeConfig.ROUTES.POLL.POLL_LIST}
@@ -702,17 +722,7 @@ function Header({ globalSearchQuery }) {
                   </Collapse>
                 </>
               )}
-              {!roleNames.some((role) =>
-                ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(role)
-              ) && (
-                <Link
-                  href={routeConfig.ROUTES.POLL.POLL_LIST}
-                  underline="none"
-                  textAlign="center"
-                >
-                  <MenuItem>{t("POLL_LIST")}</MenuItem>
-                </Link>
-              )}
+              {!hasPrivilegedPollAccess() && <PollListLink />}
               <Link
                 href={routeConfig.ROUTES.HELP_PAGE.HELP}
                 underline="none"
@@ -1037,11 +1047,7 @@ function Header({ globalSearchQuery }) {
                   {/* <NotificationsNoneOutlinedIcon />
                     ekta */}
 
-                  {(roleNames.some((role) =>
-                    ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(
-                      role
-                    )
-                  )) && (
+                  {hasPrivilegedPollAccess() && (
                     <>
                       <MenuItem
                         onClick={handleSubmenuToggle}
@@ -1062,11 +1068,7 @@ function Header({ globalSearchQuery }) {
                           disablePadding
                           style={{ background: "#f9fafc" }}
                         >
-                          {roleNames.some((role) =>
-                            ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR"].includes(
-                              role
-                            )
-                          ) && (
+                          {canCreatePoll() && (
                             <Link
                               href={routeConfig.ROUTES.POLL.POLL_FORM}
                               underline="none"
@@ -1088,19 +1090,7 @@ function Header({ globalSearchQuery }) {
                       </Collapse>
                     </>
                   )}
-                  {!roleNames.some((role) =>
-                    ["SYSTEM_ADMINISTRATION", "CONTENT_CREATOR", "CONTENT_REVIEWER", "ORG_ADMIN"].includes(
-                      role
-                    )
-                  ) && (
-                    <Link
-                      href={routeConfig.ROUTES.POLL.POLL_LIST}
-                      underline="none"
-                      textAlign="center"
-                    >
-                      <MenuItem>{t("POLL_LIST")}</MenuItem>
-                    </Link>
-                  )}
+                  {!hasPrivilegedPollAccess() && <PollListLink />}
                   <Link
                     href={routeConfig.ROUTES.HELP_PAGE.HELP}
                     underline="none"

--- a/packages/nulp_elite/src/pages/content/joinCourse.js
+++ b/packages/nulp_elite/src/pages/content/joinCourse.js
@@ -55,7 +55,7 @@ const processString = (str) => {
 // Helper function to check if a name is an assessment section
 const isAssessmentSection = (name) => {
   if (!name) return false;
-  const normalizedName = name.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+  const normalizedName = name.replaceAll(/[^a-zA-Z0-9]/g, "").toLowerCase();
   // Check for variations: assessment, asessment, course assessment, etc.
   return normalizedName.includes("assessment") || normalizedName.includes("asessment");
 };

--- a/packages/nulp_elite/src/pages/content/joinCourse.js
+++ b/packages/nulp_elite/src/pages/content/joinCourse.js
@@ -52,6 +52,14 @@ const processString = (str) => {
   return str.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
 };
 
+// Helper function to check if a name is an assessment section
+const isAssessmentSection = (name) => {
+  if (!name) return false;
+  const normalizedName = name.replace(/[^a-zA-Z0-9]/g, "").toLowerCase();
+  // Check for variations: assessment, asessment, course assessment, etc.
+  return normalizedName.includes("assessment") || normalizedName.includes("asessment");
+};
+
 const AssessmentStatusDisplay = ({ failedAssessments, onRetryAssessment, t }) => {
   return (!failedAssessments || failedAssessments.length === 0) ? null : (
     <Box className="assessment-status-container" style={{ marginBottom: "20px" }}>
@@ -1894,7 +1902,10 @@ const JoinCourse = () => {
                   {t("COURSES_MODULE")}
                 </AccordionSummary>
                 <AccordionDetails>
-                  {userData?.result?.content?.children.map((faqIndex) => (
+                  {userData?.result?.content?.children.map((faqIndex, index, array) => {
+                    const isLastItem = index === array.length - 1;
+                    const isAssessment = isAssessmentSection(faqIndex.name);
+                    return (
                     <Accordion
                       key={faqIndex.id}
                       style={{ borderRadius: "10px", margin: "10px 0" }}
@@ -2120,7 +2131,8 @@ const JoinCourse = () => {
                         )}
 
                         {/* Show assessment status AFTER the accordion content */}
-                        {faqIndex.name === "Assessment" && isEnrolled() && showAssessmentStatus && (
+                        {/* Show in assessment section OR in the last accordion box */}
+                        { isAssessment && isLastItem && isEnrolled() && showAssessmentStatus && (
                           <AssessmentStatusDisplay 
                             failedAssessments={failedAssessments}
                             onRetryAssessment={handleRetryAssessment}
@@ -2129,7 +2141,8 @@ const JoinCourse = () => {
                         )}
                       </AccordionDetails>
                     </Accordion>
-                  ))}
+                    );
+                  })}
                 </AccordionDetails>
               </Accordion>
               <Box


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/shiksha-platform/frontend-modulefederation/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

Fixed POLL menu visibility and restructured menu access based on user roles. Public users now see POLL_LIST directly, while privileged roles (SYSTEM_ADMINISTRATION, CONTENT_CREATOR, CONTENT_REVIEWER, ORG_ADMIN) see a POLL submenu with CREATE_POLL and POLL_LIST options.

### Changes

1. **Role-based POLL menu visibility**:
   - Added conditional rendering for POLL menu item to show only for SYSTEM_ADMINISTRATION, CONTENT_CREATOR, CONTENT_REVIEWER, and ORG_ADMIN roles
   - Public users (without these roles) see POLL_LIST directly in the menu

2. **POLL submenu structure for privileged roles**:
   - Created expandable POLL submenu containing:
     - CREATE_POLL (visible only to SYSTEM_ADMINISTRATION and CONTENT_CREATOR with accessWorkspace permission)
     - POLL_LIST (visible to all privileged roles: SYSTEM_ADMINISTRATION, CONTENT_CREATOR, CONTENT_REVIEWER, ORG_ADMIN)

3. **Fixed desktop menu visibility**:
   - Removed `lg-hide` CSS class from POLL MenuItem and Collapse components to fix visibility issue for CONTENT_CREATOR on desktop view
   - POLL menu is now visible on both desktop and mobile views

4. **Removed DASHBOARD from POLL submenu**:
   - Removed POLL_DASHBOARD link from POLL submenu as per requirements

5. **Consistent implementation**:
   - Applied same menu structure and role-based logic to both desktop and mobile menu views

## How to test

1. **Test as Public User (user without privileged roles)**:
   - Login as a user without SYSTEM_ADMINISTRATION, CONTENT_CREATOR, CONTENT_REVIEWER, or ORG_ADMIN roles
   - Open the user menu dropdown (click on profile icon)
   - Verify that POLL_LIST is directly visible in the menu (not inside a submenu)
   - Verify that POLL menu item (expandable submenu) is NOT visible
   - Click on POLL_LIST and verify it navigates to the poll list page

2. **Test as CONTENT_CREATOR**:
   - Login as a user with CONTENT_CREATOR role
   - Open the user menu dropdown
   - Verify that POLL menu item is visible (with expand/collapse icon)
   - Click on POLL to expand the submenu
   - Verify CREATE_POLL is visible (if user has accessWorkspace permission)
   - Verify POLL_LIST is visible inside the submenu
   - Click on POLL_LIST and verify it navigates correctly
   - Test on both desktop and mobile views

3. **Test as SYSTEM_ADMINISTRATION**:
   - Login as a user with SYSTEM_ADMINISTRATION role
   - Open the user menu dropdown
   - Verify POLL menu item is visible
   - Expand POLL submenu
   - Verify both CREATE_POLL and POLL_LIST are visible
   - Test navigation to both pages

4. **Test as CONTENT_REVIEWER or ORG_ADMIN**:
   - Login as a user with CONTENT_REVIEWER or ORG_ADMIN role
   - Open the user menu dropdown
   - Verify POLL menu item is visible
   - Expand POLL submenu
   - Verify CREATE_POLL is NOT visible (only SYSTEM_ADMINISTRATION and CONTENT_CREATOR should see it)
   - Verify POLL_LIST is visible inside the submenu

5. **Test desktop vs mobile views**:
   - Test the menu on desktop view (large screen)
   - Test the menu on mobile view (small screen)
   - Verify POLL menu is visible and functional on both views

6. **Test menu expansion/collapse**:
   - Click on POLL menu item to expand submenu
   - Verify submenu expands showing CREATE_POLL and POLL_LIST
   - Click again to collapse
   - Verify submenu collapses correctly

7. **Edge cases**:
   - Test with users having multiple roles
   - Test with users having no roles (public users)
   - Verify no console errors appear
Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)