### PR TITLE
bugfix/#262497: Fix course completion state for incomplete assessments

### DIFF
--- a/packages/nulp_elite/src/pages/content/joinCourse.js
+++ b/packages/nulp_elite/src/pages/content/joinCourse.js
@@ -392,16 +392,41 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
   }, []);
 
   const checkCourseComplition = async (allContents, userProgress) => {
-    // const contentlength = allContents.length
-    let completedCount = 0;
-    userProgress.result.contentList.map((content) => {
-      if (content.status) {
-        completedCount = completedCount + 1;
-      }
+    const contentList = userProgress?.result?.contentList || [];
+    const allContentComplete = allContents?.every((contentId) => {
+      const progress = contentList.find((item) => item.contentId === contentId);
+      return isContentComplete(contentId, progress);
     });
-    if (allContents?.length == completedCount) {
-      setIsCompleted(true);
-    }
+
+    setIsCompleted(Boolean(allContents?.length && allContentComplete));
+  };
+
+  const isAssessmentContent = (contentId) => {
+    const findContent = (node) => {
+      if (!node) return undefined;
+      if (node.identifier === contentId) return node;
+      return node.children?.reduce(
+        (match, child) => match || findContent(child),
+        undefined
+      );
+    };
+
+    const courseContent = courseData?.result?.content || userData?.result?.content;
+    return findContent(courseContent)?.contentType === "SelfAssess";
+  };
+
+  const isContentComplete = (contentId, progress) => {
+    if (!progress || progress.status !== 2) return false;
+    if (!isAssessmentContent(contentId)) return true;
+
+    return (
+      Array.isArray(progress.score) &&
+      progress.score.some(
+        (attempt) =>
+          Number.isFinite(Number(attempt.totalScore)) &&
+          Number.isFinite(Number(attempt.totalMaxScore))
+      )
+    );
   };
 
   // Helper function to find best score from attempts
@@ -519,17 +544,12 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
         const newCompletedContents = [];
 
         for (let content of data?.result?.contentList) {
-          if (content.status === 2) {
+          if (isContentComplete(content.contentId, content)) {
             newCompletedContents.push(content.contentId);
           }
         }
 
-        if (newCompletedContents.length > 0) {
-          setCompletedContents((prevContents) => [
-            ...prevContents,
-            ...newCompletedContents,
-          ]);
-        }
+        setCompletedContents(newCompletedContents);
 
         const contentList = data.result.contentList;
 
@@ -539,8 +559,8 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
         if (Array.isArray(allContents)) {
           for (let identifier of allContents) {
             const found = Array.isArray(contentList)
-              ? contentList.find(
-                (item) => item.contentId === identifier && item.status === 2
+              ? contentList.find((item) =>
+                isContentComplete(identifier, item)
               )
               : undefined;
 
@@ -606,7 +626,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
     };
     fetchChats();
     getCourseProgress();
-  }, [batchDetails, creatorId, allContents]);
+  }, [batchDetails, creatorId, allContents, courseData, userData]);
 
   // Auto-enroll SSO users as soon as batch data is available
   useEffect(() => {

--- a/packages/nulp_elite/src/pages/content/joinCourse.js
+++ b/packages/nulp_elite/src/pages/content/joinCourse.js
@@ -416,7 +416,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
   };
 
   const isContentComplete = (contentId, progress) => {
-    if (!progress || progress.status !== 2) return false;
+    if (progress?.status !== 2) return false;
     if (!isAssessmentContent(contentId)) return true;
 
     return (


### PR DESCRIPTION
This PR fixes the course completion logic to prevent incomplete assessments from being marked as completed, ensuring valid assessment scores and content status are required before showing completion indicators or enabling course completion. 
- Closes issue [#262497](https://tracker.tekdi.net/issues/262497)