### PR TITLE
Fix: assessment completion logic for exact certificate criteria

### DIFF
--- a/packages/nulp_elite/src/pages/content/joinCourse.js
+++ b/packages/nulp_elite/src/pages/content/joinCourse.js
@@ -391,11 +391,11 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
     getUserData();
   }, []);
 
-  const checkCourseComplition = async (allContents, userProgress) => {
+  const checkCourseComplition = async (allContents, userProgress, requiredScore) => {
     const contentList = userProgress?.result?.contentList || [];
     const allContentComplete = allContents?.every((contentId) => {
       const progress = contentList.find((item) => item.contentId === contentId);
-      return isContentComplete(contentId, progress);
+      return isContentComplete(contentId, progress, requiredScore);
     });
 
     setIsCompleted(Boolean(allContents?.length && allContentComplete));
@@ -415,18 +415,28 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
     return findContent(courseContent)?.contentType === "SelfAssess";
   };
 
-  const isContentComplete = (contentId, progress) => {
+  const isContentComplete = (contentId, progress, requiredScore) => {
     if (progress?.status !== 2) return false;
     if (!isAssessmentContent(contentId)) return true;
 
-    return (
-      Array.isArray(progress.score) &&
-      progress.score.some(
-        (attempt) =>
-          Number.isFinite(Number(attempt.totalScore)) &&
-          Number.isFinite(Number(attempt.totalMaxScore))
-      )
-    );
+    if (!Array.isArray(progress.score) || progress.score.length === 0) {
+      return false;
+    }
+
+    const bestScoreData = findBestScore(progress.score);
+    const currentScore = Number.parseFloat(bestScoreData.totalScore);
+    const maxScore = Number.parseFloat(bestScoreData.totalMaxScore);
+
+    if (!Number.isFinite(currentScore) || !Number.isFinite(maxScore) || maxScore === 0) {
+      return false;
+    }
+
+    const scorePercentage = (currentScore / maxScore) * 100;
+    if (!Number.isFinite(requiredScore)) {
+      return true;
+    }
+
+    return scorePercentage >= requiredScore;
   };
 
   // Helper function to find best score from attempts
@@ -518,13 +528,14 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
         const response = await axios.post(url, request);
         const data = response.data;
         setCourseProgress(data);
-        checkCourseComplition(allContents, data);
+        const requiredScore = batchDetail?.response?.certTemplates
+          ? Number(getScoreCriteria(batchDetail))
+          : 70; // Default to 70% if no criteria
+        checkCourseComplition(allContents, data, requiredScore);
 
         // Process assessment data
         if (data?.result?.contentList) {
-          const currentScore = batchDetail?.response?.certTemplates ?
-            getScoreCriteria(batchDetail) : 70; // Default to 70% if no criteria
-          processAssessmentData(data.result.contentList, currentScore);
+          processAssessmentData(data.result.contentList, requiredScore);
         }
 
         const contentIds =
@@ -544,7 +555,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
         const newCompletedContents = [];
 
         for (let content of data?.result?.contentList) {
-          if (isContentComplete(content.contentId, content)) {
+          if (isContentComplete(content.contentId, content, requiredScore)) {
             newCompletedContents.push(content.contentId);
           }
         }
@@ -560,7 +571,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
           for (let identifier of allContents) {
             const found = Array.isArray(contentList)
               ? contentList.find((item) =>
-                isContentComplete(identifier, item)
+                isContentComplete(identifier, item, requiredScore)
               )
               : undefined;
 
@@ -626,7 +637,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
     };
     fetchChats();
     getCourseProgress();
-  }, [batchDetails, creatorId, allContents, courseData, userData]);
+  }, [batchDetails, batchDetail, creatorId, allContents, courseData, userData]);
 
   // Auto-enroll SSO users as soon as batch data is available
   useEffect(() => {

--- a/packages/nulp_elite/src/pages/content/joinCourse.js
+++ b/packages/nulp_elite/src/pages/content/joinCourse.js
@@ -391,11 +391,11 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
     getUserData();
   }, []);
 
-  const checkCourseComplition = async (allContents, userProgress, requiredScore) => {
+  const checkCourseComplition = async (allContents, userProgress) => {
     const contentList = userProgress?.result?.contentList || [];
     const allContentComplete = allContents?.every((contentId) => {
       const progress = contentList.find((item) => item.contentId === contentId);
-      return isContentComplete(contentId, progress, requiredScore);
+      return isContentComplete(contentId, progress);
     });
 
     setIsCompleted(Boolean(allContents?.length && allContentComplete));
@@ -415,28 +415,18 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
     return findContent(courseContent)?.contentType === "SelfAssess";
   };
 
-  const isContentComplete = (contentId, progress, requiredScore) => {
+  const isContentComplete = (contentId, progress) => {
     if (progress?.status !== 2) return false;
     if (!isAssessmentContent(contentId)) return true;
 
-    if (!Array.isArray(progress.score) || progress.score.length === 0) {
-      return false;
-    }
-
-    const bestScoreData = findBestScore(progress.score);
-    const currentScore = Number.parseFloat(bestScoreData.totalScore);
-    const maxScore = Number.parseFloat(bestScoreData.totalMaxScore);
-
-    if (!Number.isFinite(currentScore) || !Number.isFinite(maxScore) || maxScore === 0) {
-      return false;
-    }
-
-    const scorePercentage = (currentScore / maxScore) * 100;
-    if (!Number.isFinite(requiredScore)) {
-      return true;
-    }
-
-    return scorePercentage >= requiredScore;
+    return (
+      Array.isArray(progress.score) &&
+      progress.score.some(
+        (attempt) =>
+          Number.isFinite(Number(attempt.totalScore)) &&
+          Number.isFinite(Number(attempt.totalMaxScore))
+      )
+    );
   };
 
   // Helper function to find best score from attempts
@@ -531,7 +521,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
         const requiredScore = batchDetail?.response?.certTemplates
           ? Number(getScoreCriteria(batchDetail))
           : 70; // Default to 70% if no criteria
-        checkCourseComplition(allContents, data, requiredScore);
+        checkCourseComplition(allContents, data);
 
         // Process assessment data
         if (data?.result?.contentList) {
@@ -555,7 +545,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
         const newCompletedContents = [];
 
         for (let content of data?.result?.contentList) {
-          if (isContentComplete(content.contentId, content, requiredScore)) {
+          if (isContentComplete(content.contentId, content)) {
             newCompletedContents.push(content.contentId);
           }
         }
@@ -571,7 +561,7 @@ const JoinCourse = ({ hideChrome = false, ssoMode = false }) => {
           for (let identifier of allContents) {
             const found = Array.isArray(contentList)
               ? contentList.find((item) =>
-                isContentComplete(identifier, item, requiredScore)
+                isContentComplete(identifier, item)
               )
               : undefined;
 


### PR DESCRIPTION
This PR fixes issue [#261757](https://tracker.tekdi.net/issues/261757) to correctly evaluate assessment completion against certificate score requirements and prevent false “Assessment not cleared” state after refresh.

